### PR TITLE
Fix Build Tools finder

### DIFF
--- a/Build/buildsdk.bat
+++ b/Build/buildsdk.bat
@@ -90,6 +90,7 @@ REM SET VISUAL STUDIO ENVIRONMENT
 IF EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio 12.0\VC\bin\vcvars32.bat" GOTO VS2013
 IF EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat" GOTO VS2017C
 IF EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars32.bat" GOTO VS2017
+IF EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" GOTO VS2017C
 GOTO VSMISSING
 
 :VS2013


### PR DESCRIPTION
Includes location from "Build Tools for Visual Studio 2019" installation