### PR TITLE
Build fixes

### DIFF
--- a/Build/buildconfig.bat
+++ b/Build/buildconfig.bat
@@ -76,7 +76,7 @@ IF EXIST "%ABS_ROOT%\Output\%CONFIGNAME%" RMDIR /S /Q "%ABS_ROOT%\Output\%CONFIG
 
 
 REM WHICH UNITY EXECUTABLE WILL WE USE?
-FOR /f "delims=" %%F IN ('DIR "%ProgramFiles%\Unity\Hub\Editor\" /b /on') DO SET UNITYVERSION=%%F
+FOR /f "delims=" %%F IN ('DIR "%ProgramFiles%\Unity\Hub\Editor\2017*" /b /on') DO SET UNITYVERSION=%%F
 IF EXIST "%ProgramFiles%\Unity\Hub\Editor\%UNITYVERSION%\Editor\Unity.exe" (
     SET UNITYEXE="%ProgramFiles%\Unity\Hub\Editor\%UNITYVERSION%\Editor\Unity.exe"
 ) ELSE (

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Download a copy of the sample or clone it to your local machine. I like to use G
 
 1. Install Unity by running the downloaded installer.
 
-1. You will also need Visual Studio 2013 or 2017. There should be no other environment required.
+1. You will also need Visual Studio 2013 or 2017, along with Visual Studio tools for .NET Desktop Environment. There should be no other environment required.
 
 1. Open a command window and change directory to the build directory:
 


### PR DESCRIPTION
Add missing step to readme to add 4.5 Build Tools, and make the Build scripts select the correct Unity installation 